### PR TITLE
ALS-1861: [iOS] Update Auth SDK's AutHelper to support API key

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "b6380f683b31072d77b601c88674461c11bcad5a",
-        "version" : "0.30.0"
+        "revision" : "26be7379c9d74ccf0a32d4429181ef06d72683f6",
+        "version" : "0.33.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "branch" : "0.46.0",
-        "revision" : "3c20e0be8c8246de8b8e04372404ef1f90be71b6"
+        "revision" : "473ead298e380f632336daedc6d5b6a2dd574ee1",
+        "version" : "0.76.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "b2322a067f85c230f17c80be8a67dd543454b081",
-        "version" : "0.51.0"
+        "revision" : "03e9d7279fff38042f9aed986a7fbd31ad37b30d",
+        "version" : "0.67.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/evgenyneu/keychain-swift.git", from: "20.0.0"),
-        .package(url: "https://github.com/awslabs/aws-sdk-swift", branch: "0.46.0")
+        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "0.76.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/AmazonLocationiOSAuthSDK/Auth/AuthHelper.swift
+++ b/Sources/AmazonLocationiOSAuthSDK/Auth/AuthHelper.swift
@@ -1,10 +1,12 @@
 import Foundation
+import AWSLocation
 import AwsCommonRuntimeKit
 
 @objc public class AuthHelper: NSObject {
 
     private var locationCredentialsProvider: LocationCredentialsProvider?
-    
+    private var amazonLocationClient: AmazonLocationClient?
+
     @objc public override init() {
     }
     
@@ -22,29 +24,40 @@ import AwsCommonRuntimeKit
     private func authenticateWithCognitoIdentityPoolAndRegion(identityPoolId: String, region: String) async throws -> LocationCredentialsProvider? {
         let credentialProvider = LocationCredentialsProvider(region: region, identityPoolId: identityPoolId)
         credentialProvider.setRegion(region: region)
-        try await credentialProvider.getCognitoProvider()?.refreshCognitoCredentialsIfExpired()
+        amazonLocationClient = AmazonLocationClient(locationCredentialsProvider: credentialProvider)
+        try await amazonLocationClient?.initialiseLocationClient()
         return credentialProvider
     }
 
-    @objc public func authenticateWithApiKey(apiKey: String, region: String) -> LocationCredentialsProvider {
+    @objc public func authenticateWithApiKey(apiKey: String, region: String) async throws -> LocationCredentialsProvider? {
         let credentialProvider = LocationCredentialsProvider(region: region, apiKey: apiKey)
         credentialProvider.setAPIKey(apiKey: apiKey)
         credentialProvider.setRegion(region: region)
-        locationCredentialsProvider =  credentialProvider
+        locationCredentialsProvider = credentialProvider
+        if let credentialsProvider = locationCredentialsProvider {
+            amazonLocationClient = AmazonLocationClient(locationCredentialsProvider: credentialsProvider)
+            try await amazonLocationClient?.initialiseLocationClient()
+        }
         return credentialProvider
     }
     
     public func authenticateWithCredentialsProvider(credentialsProvider: CredentialsProvider, region: String) async throws -> LocationCredentialsProvider? {
         let credentialProvider = LocationCredentialsProvider(credentialsProvider: credentialsProvider)
         credentialProvider.setRegion(region: region)
+        locationCredentialsProvider = credentialProvider
+        if let credentialsProvider = locationCredentialsProvider {
+            amazonLocationClient = AmazonLocationClient(locationCredentialsProvider: credentialsProvider)
+        }
         return credentialProvider
     }
     
-    @objc public func getLocationClient() -> AmazonLocationClient?
+    @objc public func getAmazonLocationClient() -> AmazonLocationClient?
     {
-        guard let locationCredentialsProvider = self.locationCredentialsProvider else {
-            return nil
-        }
-        return AmazonLocationClient(locationCredentialsProvider: locationCredentialsProvider)
+        return amazonLocationClient
+    }
+    
+    public func getLocationClient() -> LocationClient?
+    {
+        return amazonLocationClient?.locationClient
     }
 }

--- a/Sources/AmazonLocationiOSAuthSDK/Client/ApiKeyAuthScheme.swift
+++ b/Sources/AmazonLocationiOSAuthSDK/Client/ApiKeyAuthScheme.swift
@@ -1,0 +1,52 @@
+import SmithyHTTPAuthAPI
+import Smithy
+import SmithyHTTPAPI
+
+public let apiKeyAuthSchemeID: String = "smithy.api#noAuth"
+
+public struct ApiKeyAuthScheme: AuthScheme {
+    public var schemeID: String = apiKeyAuthSchemeID
+    public var signer: any SmithyHTTPAuthAPI.Signer
+    
+    public func customizeSigningProperties(
+        signingProperties: Smithy.Attributes,
+        context: Smithy.Context
+    ) throws -> Smithy.Attributes {
+        return signingProperties
+    }
+}
+
+public class ApiKeySigner: Signer {
+    public init() {}
+
+    public func signRequest<IdentityT>(
+        requestBuilder: SmithyHTTPAPI.HTTPRequestBuilder,
+        identity: IdentityT,
+        signingProperties: Smithy.Attributes
+    ) async throws -> SmithyHTTPAPI.HTTPRequestBuilder {
+        return requestBuilder
+    }
+}
+
+public class ApiKeyAuthSchemeResolverParameters: AuthSchemeResolverParameters {
+    public var operation: String
+    public init(operation: String) {
+        self.operation = operation
+    }
+}
+
+public class ApiKeyAuthSchemeResolver: AuthSchemeResolver {
+    public func resolveAuthScheme(params: AuthSchemeResolverParameters) throws -> [AuthOption] {
+        var validAuthOptions = Array<AuthOption>()
+        validAuthOptions.append(AuthOption(schemeID: apiKeyAuthSchemeID))
+        return validAuthOptions
+    }
+
+    public func constructParameters(context: Context) throws -> AuthSchemeResolverParameters {
+        guard let opName = context.getOperation() else {
+            throw ClientError.dataNotFound(
+                "Operation name not configured in middleware context for auth scheme resolver params construction.")
+        }
+        return ApiKeyAuthSchemeResolverParameters(operation: opName)
+    }
+}

--- a/Tests/AmazonLocationiOSAuthSDKTests/AuthHelperTests.swift
+++ b/Tests/AmazonLocationiOSAuthSDKTests/AuthHelperTests.swift
@@ -2,6 +2,8 @@ import XCTest
 import Foundation
 @testable import AmazonLocationiOSAuthSDK
 import AwsCommonRuntimeKit
+import CoreLocation
+import AWSLocation
 
 final class AuthHelperTests: XCTestCase {
     
@@ -25,9 +27,25 @@ final class AuthHelperTests: XCTestCase {
         let config = readTestConfig()
         
         let identityPoolID = config["identityPoolID"]!
+        let searchPlaceIndex = config["placeIndex"]!
+        
         let authHelper = AuthHelper()
         let authProvider = try? await authHelper.authenticateWithCognitoIdentityPool(identityPoolId: identityPoolID)
         XCTAssertEqual(authProvider!.getIdentityPoolId(), identityPoolID)
+        XCTAssertNotNil(authProvider?.getCognitoProvider())
+        
+        let biasPosition = CLLocationCoordinate2D(latitude: 47.654502614244194, longitude: -122.35862564621954)
+        let locationClient = authHelper.getLocationClient()
+        let searchPlaceIndexForSuggestionsInput = SearchPlaceIndexForSuggestionsInput(biasPosition: [biasPosition.longitude, biasPosition.latitude], indexName: searchPlaceIndex, maxResults: 15, text: "Schools")
+        let response = try await locationClient?.searchPlaceIndexForSuggestions(input: searchPlaceIndexForSuggestionsInput)
+        
+        var searchResults: [String] = []
+        if let results = response?.results {
+            for item in results {
+                searchResults.append((item.text)!)
+            }
+        }
+        XCTAssertNotEqual(searchResults.count, 0, "Search has results")
     }
     
     func testAuthWithIdentityPoolIDAndRegion() async throws {
@@ -40,15 +58,35 @@ final class AuthHelperTests: XCTestCase {
         XCTAssertEqual(authProvider!.getIdentityPoolId(), identityPoolID)
     }
     
-    func testAuthWithAPIKey() throws {
-        let config = readTestConfig()
-        
-        let apiKey = config["apiKey"]!
-        let region = config["region"]!
-
-        let authHelper = AuthHelper()
-        let authProvider = authHelper.authenticateWithApiKey(apiKey: apiKey, region: region)
-        XCTAssertNotNil(authProvider.getApiProvider())
+    func testAuthWithAPIKey() async throws {
+        do {
+            let config = readTestConfig()
+            let apiKey = config["apiKey"]!
+            let region = config["region"]!
+            let searchPlaceIndex = config["placeIndex"]!
+            
+            let authHelper = AuthHelper()
+            let authProvider = try await authHelper.authenticateWithApiKey(apiKey: apiKey, region: region)
+            
+            XCTAssertNotNil(authProvider?.getApiProvider())
+            
+            let biasPosition = CLLocationCoordinate2D(latitude: 47.654502614244194, longitude: -122.35862564621954)
+            let locationClient = authHelper.getLocationClient()
+            let searchPlaceIndexForSuggestionsInput = SearchPlaceIndexForSuggestionsInput(biasPosition: [biasPosition.longitude, biasPosition.latitude], indexName: searchPlaceIndex, key: apiKey, maxResults: 15, text: "Schools")
+            let response = try await locationClient?.searchPlaceIndexForSuggestions(input: searchPlaceIndexForSuggestionsInput)
+            
+            var searchResults: [String] = []
+            if let results = response?.results {
+                for item in results {
+                    searchResults.append((item.text)!)
+                }
+            }
+            XCTAssertNotEqual(searchResults.count, 0, "Search has results")
+        }
+        catch {
+            XCTFail(error.localizedDescription)
+            throw error
+        }
     }
     
     func testAuthWithCustomeCredentials() async throws {


### PR DESCRIPTION
By skipping any default authentication in case of API key and only use api key for authentication

